### PR TITLE
Dockerized CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,47 @@
+name: Build using Docker
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  upload-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+
+      - name: Build and export
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: .
+          tags: ghcr.io/chaichontat/calligrapher:latest
+
+      - name: Run Docker
+        run: |
+          docker run chaichontat/calligrapher:latest
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: products
+          path: public/

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run Docker
         run: |
-          docker run chaichontat/calligrapher:latest
+          docker run ghcr.io/chaichontat/calligrapher:latest
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  upload-artifact:
+  build-docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,7 +27,7 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-buildx-
+          restore-keys: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
 
       - name: Build and export
         uses: docker/build-push-action@v2
@@ -35,10 +35,11 @@ jobs:
           push: true
           context: .
           tags: ghcr.io/chaichontat/calligrapher:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Run Docker
-        run: |
-          docker run ghcr.io/chaichontat/calligrapher:latest
+        run: docker run -v ${{ github.workspace }}:/github/workspace ghcr.io/chaichontat/calligrapher:latest
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ RUN apt-get -y install build-essential libcurl4-gnutls-dev libxml2-dev libssl-de
     pandoc pandoc-citeproc wget curl git ghostscript
 
 ENV TINYTEX_VERSION=2021.08
-RUN R -e "options(Ncpus = 8); install.packages(c('tufte', 'distill', 'tinytex'))"
+RUN R -e "options(Ncpus = 8); \
+    install.packages(c('tufte', 'devtools', 'tinytex')); \
+    devtools::install_github('rstudio/distill@33f858a0e56cd083d55d8ff8df2ed7eecd27372a');"
+
 # In order to use github CDN.
 RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh
 RUN R -e "tinytex::tlmgr('install changepage ifmtarg paralist placeins sauerj tufte-latex xifthen hardwrap titlesec ragged2e textcase setspace palatino fancyhdr units ulem morefloats fpl mathpazo pdfcrop biblatex logreq')"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM r-base:latest
+
+RUN apt-get update
+RUN apt-get -y install build-essential libcurl4-gnutls-dev libxml2-dev libssl-dev \
+    pandoc pandoc-citeproc wget curl git ghostscript
+
+ENV TINYTEX_VERSION=2021.08
+RUN R -e "options(Ncpus = 8); install.packages(c('tufte', 'distill', 'tinytex'))"
+# In order to use github CDN.
+RUN wget -qO- "https://yihui.org/tinytex/install-bin-unix.sh" | sh
+RUN R -e "tinytex::tlmgr('install changepage ifmtarg paralist placeins sauerj tufte-latex xifthen hardwrap titlesec ragged2e textcase setspace palatino fancyhdr units ulem morefloats fpl mathpazo pdfcrop biblatex logreq')"
+
+# In order to use pdfcrop.
+ENV PATH="/root/.TinyTeX/bin/x86_64-linux:${PATH}"
+
+RUN mkdir /working
+WORKDIR /working
+ENTRYPOINT [ "bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN R -e "tinytex::tlmgr('install changepage ifmtarg paralist placeins sauerj tu
 # In order to use pdfcrop.
 ENV PATH="/root/.TinyTeX/bin/x86_64-linux:${PATH}"
 
-RUN mkdir /working
-WORKDIR /working
-ENTRYPOINT [ "bash" ]
+RUN mkdir -p /github/workspace
+WORKDIR /github/workspace
+
+ENTRYPOINT r -e "rmarkdown::render(\"index.Rmd\", output_dir = \"./public\", output_format = \"all\")"

--- a/index.Rmd
+++ b/index.Rmd
@@ -12,7 +12,7 @@ output:
   distill::distill_article:
     toc: true
     theme: theme/cs.css
-  # tufte::tufte_handout: default
+  tufte::tufte_handout: default
 ---
 
 Distill is a publication format for scientific and technical writing, native to the web.

--- a/index.Rmd
+++ b/index.Rmd
@@ -7,6 +7,7 @@ author:
     affiliation: Johns Hopkins University
 date: "`r Sys.Date()`"
 bibliography: references.bib
+
 csl: theme/nature.csl
 output:
   distill::distill_article:
@@ -23,4 +24,4 @@ Somehow this works.
 
 Learn more about using [Distill](https://rstudio.github.io/distill) for R Markdown.
 
-Very interesting [@amirthalingamHigherSerologicalresponses2021; @tangBNT162b2MRNA1273COVID192021].
+Very interesting [@amirthalingam2021HigherSerological; @tang2021BNT162b2MRNA1273].

--- a/references.bib
+++ b/references.bib
@@ -1,56 +1,57 @@
 
-@misc{amirthalingamHigherSerologicalresponses2021,
+@article{amirthalingam2021HigherSerological,
   title = {Higher Serological Responses and Increased Vaccine Effectiveness Demonstrate the Value of Extended Vaccine Schedules in Combatting {{COVID}}-19 in {{England}}},
-  author = {Amirthalingam, Gayatri and Bernal, Jamie Lopez and Andrews, Nick J. and Whitaker, Heather and Gower, Charlotte and Stowe, Julia and Tessier, Elise and Subbarao, Vani and Ireland, Georgina and Baawuah, Frances and Linley, Ezra and Warrener, Lenesha and O'Brien, Michelle and Whillock, Corinne and Moss, Paul and Ladhani, Shamez N. and Brown, Kevin E. and Ramsay, Mary E.},
-  year = {2021},
-  month = jul,
+  author = {Amirthalingam, Gayatri and Bernal, Jamie Lopez and Andrews, Nick J. and Whitaker, Heather and Gower, Charlotte and Stowe, Julia and Tessier, Elise and Subbarao, Vani and Ireland, Georgina and Baawuah, Frances and Linley, Ezra and Warrener, Lenesha and O’Brien, Michelle and Whillock, Corinne and Moss, Paul and Ladhani, Shamez N. and Brown, Kevin E. and Ramsay, Mary E.},
+  date = {2021-07-28},
   pages = {2021.07.26.21261140},
-  institution = {{Cold Spring Harbor Laboratory Press}},
+  publisher = {{Cold Spring Harbor Laboratory Press}},
   doi = {10.1101/2021.07.26.21261140},
-  abstract = {Introduction In January 2021, the UK decided to prioritise the delivery of the first dose of BNT162b2 (Pfizer/BioNTech) and AZD1222 (AstraZeneca) vaccines by extending the interval until the second dose up to 12 weeks. Methods Serological responses were compared after BNT162b2 and AZD1222 vaccination with varying intervals in uninfected and previously-infected adults aged 50-89 years. These findings are evaluated against real-world national vaccine effectiveness (VE) estimates against COVID-19 in England. Results We recruited 750 participants aged 50-89 years, including 126 (16.8\%) with evidence of previous infection; 421 received BNT162b2 and 329 and AZD1222. For both vaccines, over 95\% had seroconverted 35-55 days after dose one, and 100\% seroconverted 7+ days after dose 2. Following a 65-84 day interval between two doses, geometric mean titres (GMTs) at 14-34 days were 6-fold higher for BNT162b2 (6703; 95\%CI, 5887-7633) than AZD1222 (1093; 806-1483), which in turn were higher than those receiving BNT162b2 19-29 days apart (694; 540 - 893). For both vaccines, VE was higher across all age-groups from 14 days after dose two compared to one dose, but the magnitude varied with interval between doses. Higher two-dose VE was observed with {$>$}6 week intervals between BNT162b2 doses compared to the authorised 3-week schedule, including {$\geq$}80 year-olds. Conclusion Our findings support the UK approach of prioritising the first dose of COVID-19 vaccines, with evidence of higher protection following extended schedules. Given global vaccine constraints, these results are relevant to policymakers, especially with highly transmissible variants and rising incidence in many countries. Funding Public Health England},
-  copyright = {\textcopyright{} 2021, Posted by Cold Spring Harbor Laboratory. This pre-print is available under a Creative Commons License (Attribution 4.0 International), CC BY 4.0, as described at http://creativecommons.org/licenses/by/4.0/},
-  language = {en}
+  url = {https://www.medrxiv.org/content/10.1101/2021.07.26.21261140v1},
+  urldate = {2021-08-15},
+  abstract = {Introduction In January 2021, the UK decided to prioritise the delivery of the first dose of BNT162b2 (Pfizer/BioNTech) and AZD1222 (AstraZeneca) vaccines by extending the interval until the second dose up to 12 weeks. Methods Serological responses were compared after BNT162b2 and AZD1222 vaccination with varying intervals in uninfected and previously-infected adults aged 50-89 years. These findings are evaluated against real-world national vaccine effectiveness (VE) estimates against COVID-19 in England. Results We recruited 750 participants aged 50-89 years, including 126 (16.8\%) with evidence of previous infection; 421 received BNT162b2 and 329 and AZD1222. For both vaccines, over 95\% had seroconverted 35-55 days after dose one, and 100\% seroconverted 7+ days after dose 2. Following a 65-84 day interval between two doses, geometric mean titres (GMTs) at 14-34 days were 6-fold higher for BNT162b2 (6703; 95\%CI, 5887-7633) than AZD1222 (1093; 806-1483), which in turn were higher than those receiving BNT162b2 19-29 days apart (694; 540 - 893). For both vaccines, VE was higher across all age-groups from 14 days after dose two compared to one dose, but the magnitude varied with interval between doses. Higher two-dose VE was observed with {$>$}6 week intervals between BNT162b2 doses compared to the authorised 3-week schedule, including ≥80 year-olds. Conclusion Our findings support the UK approach of prioritising the first dose of COVID-19 vaccines, with evidence of higher protection following extended schedules. Given global vaccine constraints, these results are relevant to policymakers, especially with highly transmissible variants and rising incidence in many countries. Funding Public Health England},
+  langid = {english}
 }
 
-@article{bergwerkCovid19BreakthroughInfections2021,
+@article{bergwerk2021Covid19Breakthrough,
   title = {Covid-19 {{Breakthrough Infections}} in {{Vaccinated Health Care Workers}}},
-  author = {Bergwerk, Moriah and Gonen, Tal and Lustig, Yaniv and Amit, Sharon and Lipsitch, Marc and Cohen, Carmit and Mandelboim, Michal and Gal Levin, Einav and Rubin, Carmit and Indenbaum, Victoria and Tal, Ilana and Zavitan, Malka and Zuckerman, Neta and {Bar-Chaim}, Adina and Kreiss, Yitshak and {Regev-Yochay}, Gili},
-  year = {2021},
-  month = jul,
-  journal = {New England Journal of Medicine},
+  author = {Bergwerk, Moriah and Gonen, Tal and Lustig, Yaniv and Amit, Sharon and Lipsitch, Marc and Cohen, Carmit and Mandelboim, Michal and Gal Levin, Einav and Rubin, Carmit and Indenbaum, Victoria and Tal, Ilana and Zavitan, Malka and Zuckerman, Neta and Bar-Chaim, Adina and Kreiss, Yitshak and Regev-Yochay, Gili},
+  date = {2021-07-28},
+  journaltitle = {New England Journal of Medicine},
   volume = {0},
   number = {0},
   pages = {null},
   publisher = {{Massachusetts Medical Society}},
   issn = {0028-4793},
   doi = {10.1056/NEJMoa2109072},
+  url = {https://doi.org/10.1056/NEJMoa2109072},
+  urldate = {2021-08-15},
   annotation = {\_eprint: https://doi.org/10.1056/NEJMoa2109072}
 }
 
-@misc{puranikComparisonTwohighlyeffective2021,
+@article{puranik2021ComparisonTwo,
   title = {Comparison of Two Highly-Effective {{mRNA}} Vaccines for {{COVID}}-19 during Periods of {{Alpha}} and {{Delta}} Variant Prevalence},
-  author = {Puranik, Arjun and Lenehan, Patrick J. and Silvert, Eli and Niesen, Michiel J. M. and {Corchado-Garcia}, Juan and O'Horo, John C. and Virk, Abinash and Swift, Melanie D. and Halamka, John and Badley, Andrew D. and Venkatakrishnan, A. J. and Soundararajan, Venky},
-  year = {2021},
-  month = aug,
+  author = {Puranik, Arjun and Lenehan, Patrick J. and Silvert, Eli and Niesen, Michiel J. M. and Corchado-Garcia, Juan and O’Horo, John C. and Virk, Abinash and Swift, Melanie D. and Halamka, John and Badley, Andrew D. and Venkatakrishnan, A. J. and Soundararajan, Venky},
+  date = {2021-08-09},
   pages = {2021.08.06.21261707},
-  institution = {{Cold Spring Harbor Laboratory Press}},
+  publisher = {{Cold Spring Harbor Laboratory Press}},
   doi = {10.1101/2021.08.06.21261707},
+  url = {https://www.medrxiv.org/content/10.1101/2021.08.06.21261707v2},
+  urldate = {2021-08-15},
   abstract = {Although clinical trials and real-world studies have affirmed the effectiveness and safety of the FDA-authorized COVID-19 vaccines, reports of breakthrough infections and persistent emergence of new variants highlight the need to vigilantly monitor the effectiveness of these vaccines. Here we compare the effectiveness of two full-length Spike protein-encoding mRNA vaccines from Moderna (mRNA-1273) and Pfizer/BioNTech (BNT162b2) in the Mayo Clinic Health System over time from January to July 2021, during which either the Alpha or Delta variant was highly prevalent. We defined cohorts of vaccinated and unvaccinated individuals from Minnesota (n = 25,589 each) matched on age, sex, race, history of prior SARS-CoV-2 PCR testing, and date of full vaccination. Both vaccines were highly effective during this study period against SARS-CoV-2 infection (mRNA-1273: 86\%, 95\%CI: 81-90.6\%; BNT162b2: 76\%, 95\%CI: 69-81\%) and COVID-19 associated hospitalization (mRNA-1273: 91.6\%, 95\% CI: 81-97\%; BNT162b2: 85\%, 95\% CI: 73-93\%). In July, vaccine effectiveness against hospitalization has remained high (mRNA-1273: 81\%, 95\% CI: 33-96.3\%; BNT162b2: 75\%, 95\% CI: 24-93.9\%), but effectiveness against infection was lower for both vaccines (mRNA-1273: 76\%, 95\% CI: 58-87\%; BNT162b2: 42\%, 95\% CI: 13-62\%), with a more pronounced reduction for BNT162b2. Notably, the Delta variant prevalence in Minnesota increased from 0.7\% in May to over 70\% in July whereas the Alpha variant prevalence decreased from 85\% to 13\% over the same time period. Comparing rates of infection between matched individuals fully vaccinated with mRNA-1273 versus BNT162b2 across Mayo Clinic Health System sites in multiple states (Minnesota, Wisconsin, Arizona, Florida, and Iowa), mRNA-1273 conferred a two-fold risk reduction against breakthrough infection compared to BNT162b2 (IRR = 0.50, 95\% CI: 0.39-0.64). In Florida, which is currently experiencing its largest COVID-19 surge to date, the risk of infection in July after full vaccination with mRNA-1273 was about 60\% lower than after full vaccination with BNT162b2 (IRR: 0.39, 95\% CI: 0.24-0.62). Our observational study highlights that while both mRNA COVID-19 vaccines strongly protect against infection and severe disease, further evaluation of mechanisms underlying differences in their effectiveness such as dosing regimens and vaccine composition are warranted.},
-  copyright = {\textcopyright{} 2021, Posted by Cold Spring Harbor Laboratory. This pre-print is available under a Creative Commons License (Attribution-NoDerivs 4.0 International), CC BY-ND 4.0, as described at http://creativecommons.org/licenses/by-nd/4.0/},
-  language = {en}
+  langid = {english}
 }
 
-@misc{tangBNT162b2MRNA1273COVID192021,
+@article{tang2021BNT162b2MRNA1273,
   title = {{{BNT162b2}} and {{mRNA}}-1273 {{COVID}}-19 Vaccine Effectiveness against the {{Delta}} ({{B}}.1.617.2) Variant in {{Qatar}}},
-  author = {Tang, Patrick and Hasan, Mohammad R. and Chemaitelly, Hiam and Yassine, Hadi M. and Benslimane, Fatiha M. and Khatib, Hebah A. Al and AlMukdad, Sawsan and Coyle, Peter and Ayoub, Houssein H. and Kanaani, Zaina Al and Kuwari, Einas Al and Jeremijenko, Andrew and Kaleeckal, Anvar Hassan and Latif, Ali Nizar and Shaik, Riyazuddin Mohammad and Rahim, Hanan F. Abdul and Nasrallah, Gheyath K. and Kuwari, Mohamed Ghaith Al and Romaihi, Hamad Eid Al and Butt, Adeel A. and {Al-Thani}, Mohamed H. and Khal, Abdullatif Al and Bertollini, Roberto and {Abu-Raddad}, Laith J.},
-  year = {2021},
-  month = aug,
+  author = {Tang, Patrick and Hasan, Mohammad R. and Chemaitelly, Hiam and Yassine, Hadi M. and Benslimane, Fatiha M. and Khatib, Hebah A. Al and AlMukdad, Sawsan and Coyle, Peter and Ayoub, Houssein H. and Kanaani, Zaina Al and Kuwari, Einas Al and Jeremijenko, Andrew and Kaleeckal, Anvar Hassan and Latif, Ali Nizar and Shaik, Riyazuddin Mohammad and Rahim, Hanan F. Abdul and Nasrallah, Gheyath K. and Kuwari, Mohamed Ghaith Al and Romaihi, Hamad Eid Al and Butt, Adeel A. and Al-Thani, Mohamed H. and Khal, Abdullatif Al and Bertollini, Roberto and Abu-Raddad, Laith J.},
+  date = {2021-08-11},
   pages = {2021.08.11.21261885},
-  institution = {{Cold Spring Harbor Laboratory Press}},
+  publisher = {{Cold Spring Harbor Laboratory Press}},
   doi = {10.1101/2021.08.11.21261885},
-  abstract = {The SARS-CoV-2 Delta (B.1.617.2) variant of concern is expanding globally. Here, we assess real-world effectiveness of the BNT162b2 (Pfizer-BioNTech) and mRNA-1273 (Moderna) vaccines against this variant in the population of Qatar, using a matched test-negative, case- control study design. BNT162b2 effectiveness against any Delta infection, symptomatic or asymptomatic, was 64.2\% (95\% CI: 38.1-80.1\%) {$\geq$}14 days after the first dose and before the second dose, but was only 53.5\% (95\% CI: 43.9-61.4\%) {$\geq$}14 days after the second dose, in a population in which a large proportion of fully vaccinated persons received their second dose several months earlier. Corresponding effectiveness measures for mRNA-1273 were 79.0\% (95\% CI: 58.9-90.1\%) and 84.8\% (95\% CI: 75.9-90.8\%), respectively. Effectiveness against any severe, critical, or fatal COVID-19 disease due to Delta was 89.7\% (95\% CI: 61.0-98.1\%) for BNT162b2 and 100.0\% (95\% CI: 41.2-100.0\%) for mRNA-1273, {$\geq$}14 days after the second dose. Both BNT162b2 and mRNA-1273 are highly effective in preventing Delta hospitalization and death, but less so in preventing infection, particularly for BNT162b2.},
-  copyright = {\textcopyright{} 2021, Posted by Cold Spring Harbor Laboratory. The copyright holder for this pre-print is the author. All rights reserved. The material may not be redistributed, re-used or adapted without the author's permission.},
-  language = {en}
+  url = {https://www.medrxiv.org/content/10.1101/2021.08.11.21261885v1},
+  urldate = {2021-08-15},
+  abstract = {The SARS-CoV-2 Delta (B.1.617.2) variant of concern is expanding globally. Here, we assess real-world effectiveness of the BNT162b2 (Pfizer-BioNTech) and mRNA-1273 (Moderna) vaccines against this variant in the population of Qatar, using a matched test-negative, case- control study design. BNT162b2 effectiveness against any Delta infection, symptomatic or asymptomatic, was 64.2\% (95\% CI: 38.1-80.1\%) ≥14 days after the first dose and before the second dose, but was only 53.5\% (95\% CI: 43.9-61.4\%) ≥14 days after the second dose, in a population in which a large proportion of fully vaccinated persons received their second dose several months earlier. Corresponding effectiveness measures for mRNA-1273 were 79.0\% (95\% CI: 58.9-90.1\%) and 84.8\% (95\% CI: 75.9-90.8\%), respectively. Effectiveness against any severe, critical, or fatal COVID-19 disease due to Delta was 89.7\% (95\% CI: 61.0-98.1\%) for BNT162b2 and 100.0\% (95\% CI: 41.2-100.0\%) for mRNA-1273, ≥14 days after the second dose. Both BNT162b2 and mRNA-1273 are highly effective in preventing Delta hospitalization and death, but less so in preventing infection, particularly for BNT162b2.},
+  langid = {english}
 }
 
 


### PR DESCRIPTION
Goal is to simultaneously build HTML and PDF. The only suitable system for this is Rmarkdown. However, rendering PDF requires latex and reinstalling either of these during CI at runtime is unacceptable.

Goal is to form a working LaTeX and R environment for both this and for other LaTeX documents.

Signed-off-by: Chaichontat Sriworarat <34997334+chaichontat@users.noreply.github.com>